### PR TITLE
fix deep queries with $or

### DIFF
--- a/src/util/querytoknex.js
+++ b/src/util/querytoknex.js
@@ -35,7 +35,7 @@ const queryToKnex = ({ query, knex, parentKey, parentKnexMethodName, options }) 
   for (const key of Object.keys(query || {})) {
     let value = query[key]
 
-    if (isObject(value)) return queryToKnex({ query: value, knex, parentKey: key })
+    if (isObject(value)) return queryToKnex({ query: value, knex, parentKey: key, parentKnexMethodName })
 
     const knexMethodName = methods[key]
     if (knexMethodName) return queryByMethod(knex, key, value, knexMethodName)

--- a/tests/features/documents.feature
+++ b/tests/features/documents.feature
@@ -107,3 +107,15 @@ Feature: Manage documents
     Then I get 2 search results
      And search result 1 is "{ id: '0bf38966-c153-428d-a416-c6cea196f9c2', title: '123abc' }"
      And search result 2 is "{ id: 'f2f037eb-b950-4a2a-8001-b43816328cfb', title: '123123' }"
+
+Scenario: Search for documents using regex, part 5
+    Given a demo database
+      And collection 'demo'
+    When I write document "{ id: 'c07a3419-ba38-4af1-b3c0-310d14851d2c', name: 'demo1', title: 'abc123', status: 'Active' }"
+     And I write document "{ id: '0bf38966-c153-428d-a416-c6cea196f9c2', name: 'test1', title: '123abc', status: 'Failed' }"
+     And I write document "{ id: 'f2f037eb-b950-4a2a-8001-b43816328cfb', name: 'test2', title: '123123', status: 'Finished' }"
+     And I write document "{ id: 'simple-test-id', name: 'demo2', title: '123123', status: 'Finished' }"
+     And I search for documents matching "{'$and': [{'$or':[{name:{'$regex': '%test%'}},{id: {'$regex': '%test%'}}]},{'$or':[{status:'Finished'}]}]}" in "desc" order of "title"
+    Then I get 2 search results
+     And search result 1 is "{ id: 'f2f037eb-b950-4a2a-8001-b43816328cfb', name: 'test2', title: '123123', status: 'Finished' }"
+     And search result 2 is "{ id: 'simple-test-id', name: 'demo2', title: '123123', status: 'Finished' }"


### PR DESCRIPTION
This fix will fix a bug that is caused by passing deep $or props
ex of query:
``` {
  '$and': [
    {
      '$or': [
        {
          name: { '$regex': '%test%' }
        },
        { id: { '$regex': '%test%' } }
      ]
    },
    { '$or': [ { status: 'Finished' } ] }
  ]
}
```
result 
```
select * from `Documents` where ((json_extract(`data`, '$.name') like '%test%' or json_extract(`data`, '$.id') like '%test%') and (json_extract(`data`, '$.status') = 'Finished')) and `db` = X'e804636bb90f477b83d83be35efae68e' and `collection` = 'ViewAllJobModel' order by data->"$.createdAt" desc limit 10
```